### PR TITLE
updated spelling of placeholder from 'placeholer'

### DIFF
--- a/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-placeholder/cdk-drag-drop-custom-placeholder-example.ts
+++ b/src/components-examples/cdk/drag-drop/cdk-drag-drop-custom-placeholder/cdk-drag-drop-custom-placeholder-example.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
 
 /**
- * @title Drag&Drop custom placeholer
+ * @title Drag&Drop custom placeholder
  */
 @Component({
   selector: 'cdk-drag-drop-custom-placeholder-example',


### PR DESCRIPTION
Spelling issue noticed for 'placeholer' in title. Fixed to be placeholder.